### PR TITLE
Fix a bug in multi-gpu training

### DIFF
--- a/examples/segmentation/main.py
+++ b/examples/segmentation/main.py
@@ -523,6 +523,6 @@ if __name__ == "__main__":
         port = find_free_port()
         cfg.dist_url = f"tcp://localhost:{port}"
         print('using mp spawn for distributed training')
-        mp.spawn(main, nprocs=cfg.world_size, args=(cfg))
+        mp.spawn(main, nprocs=cfg.world_size, args=(cfg,))
     else:
         main(0, cfg)


### PR DESCRIPTION
Thanks for your code. There is a bug for multi-gpu training. Without the comma, `args=(cfg)` will parse `cfg` as a tuple and cause runtime error.