### PR TITLE
feat: prepare pip, checkpoint, and free-GPU release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,10 +140,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-<<<<<<< HEAD
-=======
 
 # Configuration from Wayne Mai
 wayne*
 semantic_kitti/shapenet/
->>>>>>> 3121fefbc3691185d8132fd86100353f2aa32a71

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,20 @@
+include LICENSE
+include README.md
+include requirements.txt
+include install.sh
+include update.sh
+recursive-include cfgs *.yaml
+recursive-include docs *.md *.png *.jpg *.jpeg
+recursive-include examples *.py
+recursive-include tools *.py
+recursive-include notebooks *.ipynb
+recursive-include metadata *.md *.sha256
+prune openpoints/.git
+prune .git
+prune data
+prune log
+prune logs
+prune wandb
+prune dist
+prune build
+prune *.egg-info

--- a/README.md
+++ b/README.md
@@ -68,15 +68,35 @@ In the PointNeXt project, we propose a new and flexible codebase for point-based
 ---
 
 ## Installation
-We provide a simple bash file to install the environment:
 
+### Pip packages
+
+The Python libraries are released as installable packages:
+
+```bash
+pip install openpoints pointnext-torch
 ```
-git clone --recurse-submodules git@github.com:guochengqian/PointNeXt.git
+
+`openpoints` provides the Python library. `pointnext-torch` provides PointNeXt release metadata and checkpoint download helpers, for example:
+
+```bash
+pointnext-download --list
+pointnext-download modelnet40-pointnext-s-c64 --output-dir ./hf_cache
+```
+
+The PyPI packages are importable without compiling CUDA extensions. Full training/evaluation still requires the custom CUDA/C++ ops, so use a source checkout for benchmark reproduction.
+
+### Source install for training/evaluation
+
+```bash
+git clone --recurse-submodules https://github.com/guochengqian/PointNeXt.git
 cd PointNeXt
+git submodule update --init --recursive
 source update.sh
 source install.sh
 ```
-Cuda-11.3 is required. Modify the `install.sh` if a different cuda version is used. See [Install](docs/index.md) for detail. 
+
+If SSH is configured, `git@github.com:guochengqian/PointNeXt.git` also works. CUDA 11.3 was used for the original release. Modify `install.sh` if a different CUDA/PyTorch version is used. See [Install](docs/index.md), [FAQ](docs/faq.md), and [Checkpoints](docs/checkpoints.md) for details.
 
 
 
@@ -95,7 +115,7 @@ CUDA_VISIBLE_DEVICES=$GPUs python examples/$task_folder/main.py --cfg $cfg $kwar
 
 
 ## Model Zoo (pretrained weights)
-see [Model Zoo](https://guochengqian.github.io/PointNeXt/modelzoo/). 
+See [Model Zoo](https://guochengqian.github.io/PointNeXt/modelzoo/) and [checkpoint download docs](docs/checkpoints.md). The recommended new release path hosts large checkpoints and checksum manifests on Hugging Face Hub, while GitHub Releases/PyPI host source and Python packages.
 
 ### Visualization
 More examples are available in the [paper](https://arxiv.org/abs/2206.04670). 

--- a/docs/checkpoints.md
+++ b/docs/checkpoints.md
@@ -1,0 +1,90 @@
+# Checkpoints and Hugging Face release layout
+
+PointNeXt pretrained checkpoints remain available through the links in the Model Zoo. For new releases, the recommended primary/mirror layout is a Hugging Face model repo:
+
+```text
+guochengqian/pointnext
+  README.md
+  checkpoints/
+    modelnet40/pointnext-s-c64.pth
+    scanobjectnn/pointnext-s.pth
+    s3dis/pointnext-xl-area5.pth
+    scannet/pointnext-s-val.pth
+  configs/
+    modelnet40/pointnext-s-c64.yaml
+    scanobjectnn/pointnext-s.yaml
+    s3dis/pointnext-xl.yaml
+    scannet/pointnext-s.yaml
+  metadata/
+    checksums.sha256
+```
+
+Each checkpoint should be uploaded with the exact config needed to load it. The checkpoint architecture must match the config, especially:
+
+- `model.encoder_args.width`
+- `model.encoder_args.in_channels`
+- `cls_args.num_classes` or segmentation class count
+- dataset split and number of points
+
+## Download with the helper
+
+After `pointnext-torch` is installed, a known checkpoint can be downloaded with:
+
+```bash
+pip install pointnext-torch
+pointnext-download modelnet40-pointnext-s-c64 --output-dir ./hf_cache
+```
+
+From a source checkout, the same helper is available as:
+
+```bash
+python tools/download_checkpoint.py modelnet40-pointnext-s-c64 --output-dir ./hf_cache
+```
+
+The helper uses `huggingface_hub.hf_hub_download`, then verifies SHA-256 if the Hub repo contains `metadata/checksums.sha256` or if `--sha256` is supplied.
+
+For private/gated staging repos, authenticate first:
+
+```bash
+hf auth login
+# or
+export HF_TOKEN=hf_...
+python tools/download_checkpoint.py modelnet40-pointnext-s-c64 --token "$HF_TOKEN"
+```
+
+## Generate checksums before upload
+
+Stage the Hugging Face repo locally, then generate the manifest from the real files:
+
+```bash
+python tools/write_checkpoint_manifest.py /path/to/pointnext-hf-staging
+```
+
+This writes:
+
+```text
+/path/to/pointnext-hf-staging/metadata/checksums.sha256
+```
+
+Do not invent or hand-write checkpoint hashes. Regenerate the manifest whenever an artifact changes.
+
+## Upload to Hugging Face Hub
+
+```bash
+hf auth login
+hf repos create guochengqian/pointnext --type model
+hf upload-large-folder guochengqian/pointnext /path/to/pointnext-hf-staging
+```
+
+If `guochengqian/pointnext` already exists, upload into the existing repo. Keep Google Drive links as a fallback/mirror until all public users have a working HF route.
+
+## ModelNet40 PointNeXt-S C=64 example
+
+The released ModelNet40 result in the model zoo is PointNeXt-S with width 64:
+
+```bash
+python tools/download_checkpoint.py modelnet40-pointnext-s-c64 --output-dir ./hf_cache
+CUDA_VISIBLE_DEVICES=0 python examples/classification/main.py   --cfg cfgs/modelnet40ply2048/pointnext-s.yaml   model.encoder_args.width=64   mode=test   --pretrained_path hf_cache/checkpoints/modelnet40/pointnext-s-c64.pth   wandb.use_wandb=False
+```
+
+Expected released checkpoint result: about OA 94.0 / mAcc 91.1.

--- a/docs/examples/modelnet.md
+++ b/docs/examples/modelnet.md
@@ -14,11 +14,26 @@ CUDA_VISIBLE_DEVICES=0 python examples/classification/main.py --cfg cfgs/modelne
 
 ## Test
 
-test `PointNeXt-S (C=64)`
+The default `cfgs/modelnet40ply2048/pointnext-s.yaml` config uses PointNeXt-S with width 32. The released ModelNet40 model-zoo checkpoint is the C=64 variant, so testing that checkpoint requires `model.encoder_args.width=64`.
+
+Download the checkpoint with the helper after the HF mirror is published:
 
 ```bash
-CUDA_VISIBLE_DEVICES=0 python examples/classification/main.py --cfg cfgs/modelnet40ply2048/pointnext-s.yaml model.encoder_args.width=64 mode=test --pretrained_path /path/to/your/pretrained_model
+python tools/download_checkpoint.py modelnet40-pointnext-s-c64 --output-dir ./hf_cache
 ```
+
+Test `PointNeXt-S (C=64)`:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 python examples/classification/main.py \
+  --cfg cfgs/modelnet40ply2048/pointnext-s.yaml \
+  model.encoder_args.width=64 \
+  mode=test \
+  --pretrained_path hf_cache/checkpoints/modelnet40/pointnext-s-c64.pth \
+  wandb.use_wandb=False
+```
+
+Expected released checkpoint result: about OA 94.0 / mAcc 91.1.
 
 ## Reference 
 ```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,83 @@
+# FAQ and common installation/runtime questions
+
+## I cloned the repo but `openpoints` is missing
+
+Clone with submodules:
+
+```bash
+git clone --recurse-submodules https://github.com/guochengqian/PointNeXt.git
+cd PointNeXt
+git submodule update --init --recursive
+```
+
+If you already cloned without submodules, run:
+
+```bash
+git submodule update --init --recursive
+```
+
+For a pure Python import check, the OpenPoints library can also be installed with:
+
+```bash
+pip install openpoints
+```
+
+For training/evaluation, build the CUDA/C++ extensions from a source checkout.
+
+## Does `pip install openpoints pointnext-torch` include CUDA ops?
+
+No. The PyPI packages make the Python modules importable and provide metadata/checkpoint helpers. PointNeXt training/evaluation still uses custom CUDA/C++ operators that depend on the local Python, PyTorch, CUDA, compiler, and platform ABI. Build them from source:
+
+```bash
+cd openpoints/cpp/pointnet2_batch && python setup.py install && cd ../../..
+cd openpoints/cpp/pointops && python setup.py install && cd ../../..
+```
+
+`chamfer_dist` and `emd` are optional for classification/segmentation and mainly needed for reconstruction/completion tasks.
+
+## Can I run PointNeXt on CPU only?
+
+CPU-only import and packaging smoke tests are supported. The main PointNeXt models rely on CUDA custom ops such as ball query / grouping / pointops for practical training and evaluation, so full benchmark reproduction should be run on a CUDA GPU.
+
+## What does `in_channels` mean?
+
+`in_channels` is the number of per-point input feature channels consumed by the encoder.
+
+Examples:
+
+- ModelNet40 PointNeXt-S uses xyz only: `in_channels=3`.
+- ScanObjectNN PointNeXt-S uses xyz plus an extra feature/height channel in this config: `in_channels=4`.
+- Segmentation configs may use xyz plus color/height/features depending on the dataset pipeline.
+
+A checkpoint must be evaluated with a config that matches its `in_channels`, width, number of classes, and dataset preprocessing.
+
+## Why does ModelNet40 testing use `model.encoder_args.width=64`?
+
+The default `cfgs/modelnet40ply2048/pointnext-s.yaml` is PointNeXt-S width 32. The released ModelNet40 model-zoo checkpoint is the C=64 variant, so testing that checkpoint requires:
+
+```bash
+model.encoder_args.width=64
+```
+
+Training the default width-32 config does not need this override.
+
+## Headless server visualization crashes or opens no window
+
+Visualization utilities may require an OpenGL context. On remote/headless servers, prefer offscreen rendering or run through a virtual display:
+
+```bash
+export PYVISTA_OFF_SCREEN=true
+xvfb-run -s "-screen 0 1024x768x24" python examples/segmentation/vis_results.py ...
+```
+
+If visualization still segfaults, first verify the non-visual evaluation command on the same checkpoint/config, then report the OS, GPU driver, CUDA, PyTorch, PyVista, and OpenGL/Mesa versions.
+
+## `Permission denied` when running a Python file
+
+Run Python scripts through Python, not as shell executables:
+
+```bash
+python examples/classification/main.py --cfg cfgs/modelnet40ply2048/pointnext-s.yaml
+```
+
+If a shell script fails with permission denied, either run it with `bash script.sh` or mark it executable with `chmod +x script.sh`.

--- a/docs/free_gpu_colab.md
+++ b/docs/free_gpu_colab.md
@@ -1,0 +1,44 @@
+# Free GPU smoke/evaluation
+
+A free GPU can test a small PointNeXt release path, but not every benchmark.
+
+## Good free-GPU targets
+
+- Google Colab Free, usually T4/K80/P100 depending on availability.
+- Kaggle Notebook GPU, often T4/P100.
+- Similar free notebook environments with one CUDA GPU and a working compiler.
+
+These are suitable for:
+
+- `pip install openpoints pointnext-torch` import checks.
+- source checkout with CUDA op build.
+- ModelNet40 dataset auto-download.
+- ModelNet40 PointNeXt-S C=64 checkpoint download and SHA-256 verification.
+- a single ModelNet40 test/smoke run.
+
+## Not realistic on free GPU
+
+- full S3DIS or ScanNet training
+- multi-GPU training
+- exhaustive segmentation benchmarking
+- large ablation sweeps
+
+## Colab notebook
+
+Use:
+
+```text
+notebooks/colab_free_modelnet40_smoke_eval.ipynb
+```
+
+The notebook performs:
+
+1. GPU check.
+2. clone with submodules.
+3. install source dependencies.
+4. build PointNeXt/OpenPoints CUDA ops.
+5. download the ModelNet40 PointNeXt-S C=64 checkpoint from Hugging Face Hub.
+6. verify SHA-256 when `metadata/checksums.sha256` is available.
+7. run the ModelNet40 evaluation command.
+
+Expected released checkpoint result: about OA 94.0 / mAcc 91.1. For a quick smoke test, successful import, CUDA op build, checkpoint download/hash verification, dataset load, and a completed evaluation loop are the pass criteria.

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,18 +38,36 @@ Welcome to [**OpenPoints**](https://github.com/guochengqian/openpoints) library.
 
 ## Install
 
+### Pip packages
+
+For Python import and checkpoint helper workflows:
+
+```bash
+pip install openpoints pointnext-torch
 ```
-git clone git@github.com:guochengqian/PointNeXt.git
+
+`openpoints` is the core library. `pointnext-torch` provides PointNeXt metadata and the `pointnext-download` checkpoint helper. These packages are importable without compiling CUDA extensions.
+
+### Source install for training/evaluation
+
+```bash
+git clone --recurse-submodules https://github.com/guochengqian/PointNeXt.git
 cd PointNeXt
+git submodule update --init --recursive
 source install.sh
 ```
-Note:  
 
-1) the `install.sh` requires CUDA 11.3; if another version of CUDA is used,  `install.sh` has to be modified accordingly; check your CUDA version by: `nvcc --version` before using the bash file;
+If SSH is configured, `git clone --recurse-submodules git@github.com:guochengqian/PointNeXt.git` is equivalent.
 
-2) you might need to read `install.sh` for a step-by-step installation if the bash file (`install.sh`) does not work for you by any chance;
+Note:
 
-3) for all experiments, we use wandb for online logging. Run `wandb --login` only at the first time in a new machine. Set `wandn.use_wandb=False` to use this function. Read the [official wandb documentation](https://docs.wandb.ai/quickstart) if needed.
+1) The original `install.sh` assumes CUDA 11.3-era PyTorch/CUDA settings. If another CUDA version is used, modify `install.sh` accordingly; check your CUDA version with `nvcc --version` before using the bash file.
+
+2) If the bash file does not work on your machine, read `install.sh` step by step and run the matching PyTorch/CUDA/operator build commands manually.
+
+3) PointNeXt benchmark training/evaluation uses custom CUDA/C++ ops from the `openpoints` submodule. CPU-only and PyPI-only installs are fine for import/package smoke tests, but full benchmark reproduction requires a CUDA GPU and source-built ops.
+
+4) For all experiments, we use wandb for online logging. Run `wandb --login` only the first time in a new machine. Set `wandb.use_wandb=False` to disable wandb. Read the [official wandb documentation](https://docs.wandb.ai/quickstart) if needed.
 
 
 ## General Usage 

--- a/docs/modelzoo.md
+++ b/docs/modelzoo.md
@@ -1,6 +1,13 @@
 # Model Zoo (Pretrained Models)
 
-We provide the **training logs & pretrained models** in column `our released`  *trained with the improved training strategies proposed by our PointNeXt* through Google Drive. 
+We provide the **training logs & pretrained models** in column `our released` *trained with the improved training strategies proposed by PointNeXt*. Existing public artifacts are linked through Google Drive. New release artifacts should also be mirrored on Hugging Face Hub with the layout, downloader, and checksum manifest described in [Checkpoints and Hugging Face release layout](checkpoints.md).
+
+Quick ModelNet40 checkpoint download after the HF mirror is published:
+
+```bash
+pip install pointnext-torch
+pointnext-download modelnet40-pointnext-s-c64 --output-dir ./hf_cache
+```
 
 *TP*: Throughput (instance per second) measured using an NVIDIA Tesla V100 32GB GPU and a 32 core Intel Xeon @ 2.80GHz CPU.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,44 @@
+# Release checklist for maintainers
+
+## Python packages
+
+OpenPoints and PointNeXt use separate PyPI distributions:
+
+- `openpoints`: the main Python library with models, datasets, layers, transforms, and training utilities.
+- `pointnext-torch`: PointNeXt release helpers, checkpoint downloader, and metadata.
+
+Build and check packages locally before uploading:
+
+```bash
+python -m build --sdist --wheel --no-isolation
+python -m twine check dist/*
+python -m venv /tmp/pointnext-wheel-test
+/tmp/pointnext-wheel-test/bin/python -m pip install -U pip
+/tmp/pointnext-wheel-test/bin/python -m pip install dist/*.whl
+/tmp/pointnext-wheel-test/bin/python - <<'PY'
+import pointnext_torch
+from pointnext_torch.checkpoints import KNOWN_CHECKPOINTS
+print(pointnext_torch.__version__)
+print(sorted(KNOWN_CHECKPOINTS))
+PY
+```
+
+Upload requires a maintainer-owned PyPI token:
+
+```bash
+export TWINE_USERNAME=__token__
+export TWINE_PASSWORD=pypi-...
+python -m twine upload dist/*
+```
+
+## Checkpoints
+
+Stage real checkpoint files and matching configs into the Hugging Face layout described in `docs/checkpoints.md`, generate `metadata/checksums.sha256`, then upload with `hf upload-large-folder`.
+
+## GitHub release
+
+GitHub Releases should contain source/wheel links, release notes, PyPI package names, Hugging Face checkpoint links, checksum manifest location, and the Colab/Kaggle free-GPU smoke path. Large checkpoint files should live on Hugging Face Hub rather than directly in the GitHub repository.
+
+## Issue closing policy
+
+Only close issues that are directly addressed by merged code/docs or a published release. For issues that require maintainer credentials or missing artifacts, comment with the PR/release plan and leave the issue open until the public artifact exists.

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -1,0 +1,9 @@
+# PointNeXt release metadata
+
+`checksums.sha256` is generated from the staged Hugging Face release directory after real checkpoint artifacts are present:
+
+```bash
+python tools/write_checkpoint_manifest.py /path/to/pointnext-hf-staging
+```
+
+Do not hand-write hashes. The downloader reads this manifest from the Hugging Face Hub repo and verifies downloaded checkpoints before reporting success.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,10 @@ nav:
     - examples/s3dis.md
     - examples/scannet.md
   - ... | projects/*.md
+  - Checkpoints: checkpoints.md
+  - Free GPU Colab: free_gpu_colab.md
+  - FAQ: faq.md
+  - Release checklist: release.md
   - modelzoo.md
   - changes.md
 theme:

--- a/notebooks/colab_free_modelnet40_smoke_eval.ipynb
+++ b/notebooks/colab_free_modelnet40_smoke_eval.ipynb
@@ -1,0 +1,111 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# PointNeXt ModelNet40 free-GPU smoke/eval\n",
+        "\n",
+        "This notebook targets Google Colab Free or Kaggle free GPU. It installs PointNeXt/OpenPoints from source, builds the CUDA ops, downloads the ModelNet40 PointNeXt-S C=64 checkpoint from Hugging Face Hub, verifies SHA-256 when the manifest is available, and runs the ModelNet40 test command.\n",
+        "\n",
+        "A T4/P100 is enough for this smoke path. Full S3DIS/ScanNet training is not a free-GPU target.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import torch, platform\n",
+        "print('python:', platform.python_version())\n",
+        "print('torch:', torch.__version__)\n",
+        "print('cuda available:', torch.cuda.is_available())\n",
+        "print('gpu:', torch.cuda.get_device_name(0) if torch.cuda.is_available() else 'CPU only')\n",
+        "assert torch.cuda.is_available(), 'Enable GPU runtime: Runtime -> Change runtime type -> GPU'\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Clone with submodules. If you are testing a PR branch, replace --branch master.\n",
+        "!git clone --recurse-submodules https://github.com/guochengqian/PointNeXt.git\n",
+        "%cd PointNeXt\n",
+        "!git submodule update --init --recursive\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Install Python deps. Colab's preinstalled PyTorch is usually OK; avoid reinstalling torch unless needed.\n",
+        "!python -m pip install -U pip setuptools wheel ninja gdown huggingface_hub\n",
+        "!python -m pip install -r requirements.txt --no-deps\n",
+        "!python -m pip install -e openpoints\n",
+        "!python -m pip install -e .\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Build the CUDA ops used by PointNeXt. This takes a few minutes on Colab Free.\n",
+        "!cd openpoints/cpp/pointnet2_batch && python setup.py install\n",
+        "!cd openpoints/cpp/pointops && python setup.py install\n",
+        "# chamfer/emd are optional for classification, but building them makes the environment closer to a full source install.\n",
+        "!cd openpoints/cpp/chamfer_dist && python setup.py install\n",
+        "!cd openpoints/cpp/emd && python setup.py install\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Download the ModelNet40 PointNeXt-S C=64 checkpoint.\n",
+        "# If the HF repo is still private, set HF_TOKEN in Colab secrets and pass --token.\n",
+        "!python tools/download_checkpoint.py modelnet40-pointnext-s-c64 --output-dir ./hf_cache\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Run ModelNet40 evaluation. The dataset is downloaded automatically by OpenPoints.\n",
+        "CKPT='hf_cache/checkpoints/modelnet40/pointnext-s-c64.pth'\n",
+        "!CUDA_VISIBLE_DEVICES=0 python examples/classification/main.py --cfg cfgs/modelnet40ply2048/pointnext-s.yaml model.encoder_args.width=64 mode=test --pretrained_path $CKPT wandb.use_wandb=False dataloader.num_workers=2\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Expected released checkpoint result: about OA 94.0 / mAcc 91.1 on ModelNet40. For a quick smoke check, successful CUDA op import, checkpoint download/hash verification, dataset load, and a completed test loop are the main pass criteria.\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "pygments_lexer": "ipython3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/pointnext_torch/__init__.py
+++ b/pointnext_torch/__init__.py
@@ -1,0 +1,24 @@
+"""PointNeXt release helper package.
+
+The research models and training/evaluation code live in the PointNeXt
+repository and the OpenPoints package.  This small package provides stable
+paths, metadata, and checkpoint download helpers for pip-installed users.
+"""
+
+from .checkpoints import (
+    DEFAULT_REPO_ID,
+    KNOWN_CHECKPOINTS,
+    CheckpointSpec,
+    download_checkpoint,
+    verify_sha256,
+)
+
+__all__ = [
+    "DEFAULT_REPO_ID",
+    "KNOWN_CHECKPOINTS",
+    "CheckpointSpec",
+    "download_checkpoint",
+    "verify_sha256",
+]
+
+__version__ = "0.1.0"

--- a/pointnext_torch/checkpoints.py
+++ b/pointnext_torch/checkpoints.py
@@ -1,0 +1,162 @@
+"""Utilities for downloading and verifying PointNeXt checkpoints."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+DEFAULT_REPO_ID = "guochengqian/pointnext"
+DEFAULT_MANIFEST = "metadata/checksums.sha256"
+
+
+@dataclass(frozen=True)
+class CheckpointSpec:
+    """Description of a released checkpoint and its matching config."""
+
+    key: str
+    filename: str
+    config: str
+    dataset: str
+    architecture: str
+    expected_metric: str
+    sha256: Optional[str] = None
+    notes: str = ""
+
+
+# SHA-256 values are intentionally left unset until the artifacts are staged on
+# Hugging Face and metadata/checksums.sha256 is generated from the real files.
+KNOWN_CHECKPOINTS: Dict[str, CheckpointSpec] = {
+    "modelnet40-pointnext-s-c64": CheckpointSpec(
+        key="modelnet40-pointnext-s-c64",
+        filename="checkpoints/modelnet40/pointnext-s-c64.pth",
+        config="configs/modelnet40/pointnext-s-c64.yaml",
+        dataset="ModelNet40Ply2048",
+        architecture="PointNeXt-S, width=64, in_channels=3, num_classes=40",
+        expected_metric="OA 94.0 / mAcc 91.1 (released checkpoint)",
+        notes="Use cfgs/modelnet40ply2048/pointnext-s.yaml with model.encoder_args.width=64.",
+    ),
+    "scanobjectnn-pointnext-s": CheckpointSpec(
+        key="scanobjectnn-pointnext-s",
+        filename="checkpoints/scanobjectnn/pointnext-s.pth",
+        config="configs/scanobjectnn/pointnext-s.yaml",
+        dataset="ScanObjectNN hardest split",
+        architecture="PointNeXt-S, width=32, in_channels=4, num_classes=15",
+        expected_metric="OA 88.20 / mAcc 86.84 (released checkpoint)",
+    ),
+}
+
+
+def sha256_file(path: os.PathLike[str] | str, chunk_size: int = 1024 * 1024) -> str:
+    """Return the SHA-256 hex digest for *path*."""
+
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(chunk_size), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_sha256(path: os.PathLike[str] | str, expected_sha256: str) -> str:
+    """Verify *path* against *expected_sha256* and return the actual digest."""
+
+    actual = sha256_file(path)
+    if actual.lower() != expected_sha256.lower():
+        raise RuntimeError(
+            f"SHA-256 mismatch for {path}: expected {expected_sha256}, got {actual}"
+        )
+    return actual
+
+
+def parse_sha256_manifest(lines: Iterable[str]) -> Dict[str, str]:
+    """Parse a sha256sum-style manifest into {relative_path: digest}."""
+
+    manifest: Dict[str, str] = {}
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            continue
+        digest, filename = parts
+        filename = filename.lstrip("*").strip()
+        manifest[filename] = digest
+    return manifest
+
+
+def _manifest_digest(repo_id: str, filename: str, revision: Optional[str]) -> Optional[str]:
+    try:
+        from huggingface_hub import hf_hub_download
+    except ImportError:
+        return None
+
+    try:
+        manifest_path = hf_hub_download(
+            repo_id=repo_id,
+            filename=DEFAULT_MANIFEST,
+            revision=revision,
+            repo_type="model",
+        )
+    except Exception:
+        return None
+
+    with open(manifest_path, "r", encoding="utf-8") as handle:
+        manifest = parse_sha256_manifest(handle)
+    return manifest.get(filename)
+
+
+def download_checkpoint(
+    key_or_filename: str,
+    *,
+    repo_id: str = DEFAULT_REPO_ID,
+    revision: Optional[str] = None,
+    output_dir: os.PathLike[str] | str = "checkpoints",
+    sha256: Optional[str] = None,
+    token: Optional[str] = None,
+) -> Path:
+    """Download a PointNeXt checkpoint from Hugging Face Hub.
+
+    Args:
+        key_or_filename: A key from ``KNOWN_CHECKPOINTS`` or a Hub filename such
+            as ``checkpoints/modelnet40/pointnext-s-c64.pth``.
+        repo_id: Hugging Face model repo ID.
+        revision: Optional branch/tag/commit on the Hub repo.
+        output_dir: Local directory where the file should be copied/downloaded.
+        sha256: Optional expected SHA-256. If omitted, the function tries to read
+            ``metadata/checksums.sha256`` from the Hub repo.
+        token: Optional Hugging Face token for private/gated repos.
+
+    Returns:
+        Path to the downloaded checkpoint.
+    """
+
+    try:
+        from huggingface_hub import hf_hub_download
+    except ImportError as exc:
+        raise ImportError(
+            "Install checkpoint support with `pip install huggingface_hub` or "
+            "`pip install pointnext-torch`."
+        ) from exc
+
+    spec = KNOWN_CHECKPOINTS.get(key_or_filename)
+    filename = spec.filename if spec is not None else key_or_filename
+    expected = sha256 or (spec.sha256 if spec is not None else None)
+    if expected is None:
+        expected = _manifest_digest(repo_id, filename, revision)
+
+    local_path = hf_hub_download(
+        repo_id=repo_id,
+        filename=filename,
+        revision=revision,
+        repo_type="model",
+        local_dir=str(output_dir),
+        local_dir_use_symlinks=False,
+        token=token,
+    )
+    path = Path(local_path)
+    if expected:
+        verify_sha256(path, expected)
+    return path

--- a/pointnext_torch/cli.py
+++ b/pointnext_torch/cli.py
@@ -1,0 +1,52 @@
+"""Command-line helpers for the pointnext-torch package."""
+
+from __future__ import annotations
+
+import argparse
+
+from .checkpoints import DEFAULT_REPO_ID, KNOWN_CHECKPOINTS, download_checkpoint
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Download PointNeXt checkpoints from Hugging Face Hub")
+    parser.add_argument(
+        "checkpoint",
+        nargs="?",
+        default="modelnet40-pointnext-s-c64",
+        help="Known checkpoint key or Hub filename. Use --list to show known keys.",
+    )
+    parser.add_argument("--repo-id", default=DEFAULT_REPO_ID, help="Hugging Face model repo ID")
+    parser.add_argument("--revision", default=None, help="Optional Hub revision")
+    parser.add_argument("--output-dir", default="checkpoints", help="Local output/cache directory")
+    parser.add_argument("--sha256", default=None, help="Expected SHA-256 override")
+    parser.add_argument("--token", default=None, help="Optional Hugging Face token")
+    parser.add_argument("--list", action="store_true", help="List known checkpoint keys and exit")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.list:
+        for key, spec in KNOWN_CHECKPOINTS.items():
+            print(
+                f"{key}\n"
+                f"  file: {spec.filename}\n"
+                f"  config: {spec.config}\n"
+                f"  expected: {spec.expected_metric}"
+            )
+        return 0
+    path = download_checkpoint(
+        args.checkpoint,
+        repo_id=args.repo_id,
+        revision=args.revision,
+        output_dir=args.output_dir,
+        sha256=args.sha256,
+        token=args.token,
+    )
+    print(path)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,53 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pointnext-torch"
+version = "0.1.0"
+description = "PointNeXt release helpers, checkpoint download utilities, and metadata for pip-installed OpenPoints/PointNeXt users."
+readme = "README.md"
+requires-python = ">=3.8"
+license = "MIT"
+authors = [{ name = "Guocheng Qian" }]
+keywords = ["point cloud", "deep learning", "pytorch", "PointNeXt", "OpenPoints"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Science/Research",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+  "openpoints>=0.1.0",
+  "huggingface_hub>=0.19",
+  "PyYAML>=5.4",
+]
+
+[project.optional-dependencies]
+dev = ["build>=1", "twine>=4", "pytest>=7"]
+docs = ["mkdocs-material", "mkdocs-awesome-pages-plugin", "mdx_truly_sane_lists"]
+
+[project.urls]
+Homepage = "https://github.com/guochengqian/PointNeXt"
+Repository = "https://github.com/guochengqian/PointNeXt"
+Documentation = "https://guochengqian.github.io/PointNeXt/"
+Issues = "https://github.com/guochengqian/PointNeXt/issues"
+Checkpoints = "https://huggingface.co/guochengqian/pointnext"
+
+[project.scripts]
+pointnext-download = "pointnext_torch.cli:main"
+
+[tool.setuptools]
+packages = ["pointnext_torch"]
+include-package-data = true
+zip-safe = false
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/tools/download_checkpoint.py
+++ b/tools/download_checkpoint.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Download a PointNeXt checkpoint from Hugging Face Hub and verify SHA-256."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from pointnext_torch.checkpoints import DEFAULT_REPO_ID, KNOWN_CHECKPOINTS, download_checkpoint
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "checkpoint",
+        nargs="?",
+        default="modelnet40-pointnext-s-c64",
+        help="Known key or Hub filename. Use --list for keys.",
+    )
+    parser.add_argument("--repo-id", default=DEFAULT_REPO_ID)
+    parser.add_argument("--revision", default=None)
+    parser.add_argument("--output-dir", default="checkpoints")
+    parser.add_argument("--sha256", default=None, help="Expected SHA-256 override")
+    parser.add_argument("--token", default=None, help="HF token for private/gated repos")
+    parser.add_argument("--list", action="store_true")
+    args = parser.parse_args()
+
+    if args.list:
+        for key, spec in KNOWN_CHECKPOINTS.items():
+            print(f"{key}: {spec.filename} ({spec.expected_metric})")
+        return 0
+
+    path = download_checkpoint(
+        args.checkpoint,
+        repo_id=args.repo_id,
+        revision=args.revision,
+        output_dir=args.output_dir,
+        sha256=args.sha256,
+        token=args.token,
+    )
+    print(f"Downloaded checkpoint: {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/write_checkpoint_manifest.py
+++ b/tools/write_checkpoint_manifest.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Generate a sha256sum-style manifest for staged PointNeXt checkpoint files."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+from typing import Iterable
+
+DEFAULT_PATTERNS = ("*.pth", "*.pt", "*.ckpt", "*.safetensors", "*.yaml")
+
+
+def sha256_file(path: Path, chunk_size: int = 1024 * 1024) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(chunk_size), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def iter_files(root: Path, patterns: Iterable[str]):
+    seen = set()
+    for pattern in patterns:
+        for path in sorted(root.rglob(pattern)):
+            if path.is_file() and path not in seen:
+                seen.add(path)
+                yield path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", type=Path, help="Staged HF repo directory")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Output manifest path. Defaults to <root>/metadata/checksums.sha256",
+    )
+    parser.add_argument(
+        "--pattern",
+        action="append",
+        dest="patterns",
+        default=None,
+        help="Glob pattern to include; may be repeated. Defaults to checkpoint/config patterns.",
+    )
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    if not root.exists():
+        raise FileNotFoundError(root)
+    output = args.output or (root / "metadata" / "checksums.sha256")
+    patterns = args.patterns or list(DEFAULT_PATTERNS)
+
+    lines = []
+    for path in iter_files(root, patterns):
+        if output.resolve() == path.resolve():
+            continue
+        rel = path.relative_to(root).as_posix()
+        lines.append(f"{sha256_file(path)}  {rel}\n")
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text("".join(lines), encoding="utf-8")
+    print(f"Wrote {len(lines)} entries to {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add `pointnext-torch` packaging metadata plus a small importable helper package and `pointnext-download` CLI.
- Update install docs to distinguish pip-installable libraries from source builds needed for CUDA/C++ ops and full benchmark reproduction.
- Add checkpoint/Hugging Face release layout docs, checksum-manifest generation, downloader script, and release checklist.
- Add a Colab Free ModelNet40 smoke/eval notebook and clarify the ModelNet40 PointNeXt-S C=64 checkpoint vs default width=32 config.
- Update the `openpoints` submodule pointer to the OpenPoints packaging/optional-CUDA PR: https://github.com/guochengqian/openpoints/pull/14

## Verification
- `python3 -m compileall -q pointnext_torch tools/download_checkpoint.py tools/write_checkpoint_manifest.py`
- `python3 -m pointnext_torch.cli --list`
- `python3 tools/write_checkpoint_manifest.py <tmp-release-dir>` produced a non-empty `metadata/checksums.sha256`.
- `python3 -m build --sdist --wheel --no-isolation`
- `python3 -m twine check dist/*`
- Fresh venv wheel smoke: installed `openpoints-0.1.0-py3-none-any.whl` plus `pointnext_torch-0.1.0-py3-none-any.whl`, imported `pointnext_torch`, parsed a checksum manifest, and ran `pointnext-download --list`.
- Notebook JSON validation passed for `notebooks/colab_free_modelnet40_smoke_eval.ipynb`.

## Release blockers that require maintainer credentials/artifacts
- PyPI upload for `openpoints` and `pointnext-torch` requires maintainer-owned PyPI API tokens.
- Hugging Face upload for checkpoints requires maintainer-owned `HF_TOKEN`/`hf auth login` and the actual `.pth` checkpoint files.
- The PR documents exact commands for both uploads but does not upload without credentials.

## Free GPU expectation
Colab Free/T4 is appropriate for import smoke, CUDA-op build smoke, checkpoint download/hash verification, and a small ModelNet40 evaluation. It is not a realistic target for full S3DIS/ScanNet training.
