### PR TITLE
Support RTX 5090 / Blackwell source install; bump to 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ source update.sh
 source install.sh
 ```
 
-If SSH is configured, `git@github.com:guochengqian/PointNeXt.git` also works. CUDA 11.3 was used for the original release. Modify `install.sh` if a different CUDA/PyTorch version is used. See [Install](docs/index.md), [FAQ](docs/faq.md), and [Checkpoints](docs/checkpoints.md) for details.
+If SSH is configured, `git@github.com:guochengqian/PointNeXt.git` also works. The current `install.sh` targets modern NVIDIA GPUs, including **Blackwell (RTX 50-series / RTX 5090, sm_120)**, via a uv + Python 3.12 environment with PyTorch ≥2.7 built for CUDA 12.8 (`cu128`). Blackwell requires CUDA ≥12.8 and PyTorch ≥2.7; the legacy CUDA 11.3 recipe (kept commented at the bottom of `install.sh`) does not run on an RTX 5090. To compile the CUDA ops you also need a matching CUDA toolkit (`nvcc`) and a host compiler the toolkit supports (CUDA 12.x needs `g++` < 14, e.g. `sudo apt install gcc-13 g++-13`). Modify `install.sh` for a different CUDA/PyTorch version. See [Install](docs/index.md), [FAQ](docs/faq.md), and [Checkpoints](docs/checkpoints.md) for details.
 
 
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -35,6 +35,20 @@ cd openpoints/cpp/pointops && python setup.py install && cd ../../..
 
 `chamfer_dist` and `emd` are optional for classification/segmentation and mainly needed for reconstruction/completion tasks.
 
+## How do I build the CUDA ops for an RTX 5090 / Blackwell GPU?
+
+Blackwell (`sm_120`) needs CUDA ≥12.8 and PyTorch ≥2.7. Use the default `install.sh`
+(uv + Python 3.12 + `cu128` PyTorch), and before compiling make sure:
+
+- `CUDA_HOME`/`PATH` point at a CUDA ≥12.8 toolkit (`nvcc --version`).
+- The host compiler is one the toolkit accepts — CUDA 12.x requires `g++` < 14, so
+  install e.g. `sudo apt install gcc-13 g++-13` and `export CC=gcc-13 CXX=g++-13`.
+- `TORCH_CUDA_ARCH_LIST` includes `12.0` (the default in `install.sh` does).
+
+The ops were ported to NumPy 2.x, so they compile against the NumPy that ships with
+Python 3.12 environments. `torch-scatter` (used by a few optional backbones) may need
+to compile from source since prebuilt wheels can lag new PyTorch releases.
+
 ## Can I run PointNeXt on CPU only?
 
 CPU-only import and packaging smoke tests are supported. The main PointNeXt models rely on CUDA custom ops such as ball query / grouping / pointops for practical training and evaluation, so full benchmark reproduction should be run on a CUDA GPU.

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ If SSH is configured, `git clone --recurse-submodules git@github.com:guochengqia
 
 Note:
 
-1) The original `install.sh` assumes CUDA 11.3-era PyTorch/CUDA settings. If another CUDA version is used, modify `install.sh` accordingly; check your CUDA version with `nvcc --version` before using the bash file.
+1) `install.sh` targets modern NVIDIA GPUs, including Blackwell (RTX 50-series / RTX 5090, `sm_120`), using a uv + Python 3.12 environment with PyTorch ≥2.7 built for CUDA 12.8 (`cu128`). Blackwell requires CUDA ≥12.8 and PyTorch ≥2.7. Compiling the CUDA ops needs a CUDA toolkit (`nvcc`, check `nvcc --version`) and a host compiler the toolkit supports (CUDA 12.x needs `g++` < 14 — install e.g. `gcc-13`/`g++-13` and set `CC`/`CXX`). If another CUDA version is used, modify `install.sh` accordingly. The legacy CUDA 11.3 recipe is kept commented at the bottom of `install.sh` for older GPUs and does not run on an RTX 5090.
 
 2) If the bash file does not work on your machine, read `install.sh` step by step and run the matching PyTorch/CUDA/operator build commands manually.
 

--- a/install.sh
+++ b/install.sh
@@ -1,54 +1,97 @@
 #!/usr/bin/env bash
-# command to install this enviroment: source init.sh
+# Install the PointNeXt / OpenPoints source environment for training & evaluation.
+#
+# Default recipe targets MODERN NVIDIA GPUs, including Blackwell (RTX 50-series /
+# RTX 5090, compute capability sm_120), using:
+#   * uv-managed virtual environment, Python 3.12
+#   * PyTorch >= 2.7 built against CUDA 12.8 (cu128 wheels)
+#   * the custom CUDA/C++ operators compiled for your GPU architecture
+#
+# Blackwell (sm_120) REQUIRES CUDA >= 12.8 and PyTorch >= 2.7. Older PyTorch/CUDA
+# stacks (e.g. the original CUDA 11.3 recipe, kept commented at the bottom) will
+# NOT run on an RTX 5090.
+#
+# Usage:  source install.sh
+set -e
 
-# install miniconda3 if not installed yet.
-#wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-#bash Miniconda3-latest-Linux-x86_64.sh
-#source ~/.bashrc
-
-
-# The following 4 lines are only for slurm machines. uncomment if needed.  
-export TORCH_CUDA_ARCH_LIST="6.1;6.2;7.0;7.5;8.0"   # a100: 8.0; v100: 7.0; 2080ti: 7.5; titan xp: 6.1
-module purge
-module load cuda/11.1.1
-module load gcc/7.5.0
-
-# download openpoints
-# git submodule add git@github.com:guochengqian/openpoints.git
+# Make sure submodules are present.
 git submodule update --init --recursive
-git submodule update --remote --merge # update to the latest version
 
-# install PyTorch
-conda deactivate
-conda env remove --name openpoints
-conda create -n openpoints -y python=3.7 numpy=1.20 numba
-conda activate openpoints
+# ---------------------------------------------------------------------------
+# 0. Toolchain
+# ---------------------------------------------------------------------------
+# A full CUDA toolkit (nvcc) is needed to compile the operators. Point CUDA_HOME
+# at it and put nvcc on PATH. Adjust the version to match your machine.
+export CUDA_HOME=${CUDA_HOME:-/usr/local/cuda}
+export PATH=${CUDA_HOME}/bin:${PATH}
 
-# please always double check installation for pytorch and torch-scatter from the official documentation
-conda install -y pytorch=1.10.1 torchvision cudatoolkit=11.3 -c pytorch -c nvidia
-pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.1+cu113.html
+# PyTorch's cpp_extension rejects host compilers newer than what the CUDA toolkit
+# officially supports (e.g. CUDA 12.x wants g++ < 14). If your default gcc is too
+# new, install an older one (`sudo apt install gcc-13 g++-13`) and select it here.
+export CC=${CC:-gcc-13}
+export CXX=${CXX:-g++-13}
 
-pip install -r requirements.txt
+# GPU architectures to compile the CUDA kernels for. Include 12.0 for Blackwell.
+#   Ampere 3090/A100: 8.0/8.6 ; Ada 4090: 8.9 ; Hopper H100: 9.0 ; Blackwell 5090: 12.0
+export TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST:-"8.0;8.6;8.9;9.0;12.0"}
+export MAX_JOBS=${MAX_JOBS:-$(nproc)}
 
-# install cpp extensions, the pointnet++ library
-cd openpoints/cpp/pointnet2_batch
-python setup.py install
-cd ../
+# ---------------------------------------------------------------------------
+# 1. Python environment (uv + Python 3.12)
+# ---------------------------------------------------------------------------
+# Install uv first if missing:  curl -LsSf https://astral.sh/uv/install.sh | sh
+uv venv --python 3.12 .venv
+source .venv/bin/activate
 
-# grid_subsampling library. necessary only if interested in S3DIS_sphere
-cd subsampling
-python setup.py build_ext --inplace
-cd ..
+# ---------------------------------------------------------------------------
+# 2. PyTorch with CUDA 12.8 (Blackwell / sm_120 support)
+# ---------------------------------------------------------------------------
+# Check https://pytorch.org for the wheel/index matching your CUDA if different.
+uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cu128
+
+# ---------------------------------------------------------------------------
+# 3. Python dependencies
+# ---------------------------------------------------------------------------
+uv pip install -r requirements.txt
+
+# torch-scatter, built against the installed torch. Prebuilt wheels often lag new
+# torch releases, so compile from source (uses the toolchain configured above).
+uv pip install --no-build-isolation torch-scatter
+
+# ---------------------------------------------------------------------------
+# 4. Custom CUDA/C++ extensions (the pointnet++ / pointops libraries)
+# ---------------------------------------------------------------------------
+# pointnet2 batch ops (ball query / grouping / sampling / interpolation)
+( cd openpoints/cpp/pointnet2_batch && uv pip install --no-build-isolation -e . )
+
+# grid_subsampling (needed only for S3DIS_sphere)
+( cd openpoints/cpp/subsampling && python setup.py build_ext --inplace )
+
+# pointops (Point Transformer / Stratified Transformer)
+( cd openpoints/cpp/pointops && uv pip install --no-build-isolation -e . )
+
+# chamfer_dist + emd (reconstruction / completion tasks only)
+( cd openpoints/cpp/chamfer_dist && uv pip install --no-build-isolation -e . )
+( cd openpoints/cpp/emd && uv pip install --no-build-isolation -e . )
+
+echo ""
+echo "Done. Quick check:"
+echo "  python -c \"import torch; print(torch.__version__, torch.cuda.get_device_name(0), torch.cuda.get_device_capability(0))\""
 
 
-# # point transformer library. Necessary only if interested in Point Transformer and Stratified Transformer
-cd pointops/
-python setup.py install
-cd ..
-
-# Blow are functions that optional. Necessary only if interested in reconstruction tasks such as completion
-cd chamfer_dist
-python setup.py install --user
-cd ../emd
-python setup.py install --user
-cd ../../../
+# ===========================================================================
+# LEGACY recipe (CUDA 11.3 / PyTorch 1.10, conda). Kept for reference only.
+# Does NOT support Blackwell (RTX 5090). Uncomment and adapt for older GPUs.
+# ===========================================================================
+# export TORCH_CUDA_ARCH_LIST="6.1;6.2;7.0;7.5;8.0"
+# conda deactivate
+# conda env remove --name openpoints
+# conda create -n openpoints -y python=3.7 numpy=1.20 numba
+# conda activate openpoints
+# conda install -y pytorch=1.10.1 torchvision cudatoolkit=11.3 -c pytorch -c nvidia
+# pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.1+cu113.html
+# pip install -r requirements.txt
+# cd openpoints/cpp/pointnet2_batch && python setup.py install && cd ../
+# cd subsampling && python setup.py build_ext --inplace && cd ..
+# cd pointops/ && python setup.py install && cd ..
+# cd chamfer_dist && python setup.py install --user && cd ../emd && python setup.py install --user && cd ../../../

--- a/pointnext_official/__init__.py
+++ b/pointnext_official/__init__.py
@@ -21,4 +21,4 @@ __all__ = [
     "verify_sha256",
 ]
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pointnext_official"
-version = "0.1.1"
+version = "0.1.2"
 description = "PointNeXt release helpers, checkpoint download utilities, and metadata for pip-installed OpenPoints/PointNeXt users."
 readme = "README.md"
 requires-python = ">=3.8"
@@ -24,7 +24,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-  "openpoints>=0.1.1",
+  "openpoints>=0.1.2",
   "huggingface_hub>=0.19",
   "PyYAML>=5.4",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,25 @@
-scikit-learn==1.0.2
-pickleshare==0.7.5
-ninja==1.10.2.3
+# Python dependencies for source training/evaluation.
+# Versions relaxed to floors so the stack installs on modern Python (3.10-3.12)
+# and NumPy 2.x, as required by the CUDA 12.8+/PyTorch 2.7+ build used for
+# NVIDIA Blackwell GPUs (e.g. RTX 5090, sm_120). Install PyTorch separately
+# from the correct CUDA index first (see install.sh).
+scikit-learn>=1.3
+pickleshare>=0.7.5
+ninja>=1.11
 gdown
-easydict==1.9
-PyYAML==6.0
-protobuf==3.19.4
-tensorboard==2.8.0
-termcolor==1.1.0
-tqdm==4.62.3
-multimethod==1.7
-h5py==3.6.0
-matplotlib==3.5.1
+easydict>=1.10
+PyYAML>=6.0.1
+protobuf>=4.23
+tensorboard>=2.14
+termcolor>=2.0
+tqdm>=4.62
+multimethod>=1.9
+h5py>=3.9
+matplotlib>=3.7
 wandb
 pyvista
-setuptools==59.5.0
-Cython==0.29.28
+setuptools>=68
+Cython>=3.0
 pandas
 deepspeed
 shortuuid


### PR DESCRIPTION
Updates the source training/eval install so the OpenPoints CUDA ops build and run on NVIDIA Blackwell (RTX 50-series / RTX 5090, `sm_120`), verified end-to-end on a 5090.

Depends on guochengqian/openpoints#15 (bundled here via the submodule pointer bump).

## Changes
- **install.sh**: rewrite for uv + Python 3.12 + PyTorch 2.7/`cu128`; set `TORCH_CUDA_ARCH_LIST` to include `12.0`; document the CUDA ≥12.8 toolkit and the `g++ < 14` host-compiler requirement (e.g. `gcc-13`); build ops via `uv pip install --no-build-isolation -e`. Legacy CUDA 11.3 conda recipe kept commented for older GPUs.
- **requirements.txt**: relax hard pins with no Python 3.12 / NumPy 2.x wheels (scikit-learn, h5py, matplotlib, Cython<3, setuptools==59.5.0, …) to floors.
- **README / docs / faq**: document the Blackwell install path and toolchain.
- Bump `openpoints` submodule to the 0.1.2 (Blackwell) commit; require `openpoints>=0.1.2`; bump `pointnext_official` to **0.1.2**.

## Verified on RTX 5090
Full PointNeXt-S forward+backward passes; all CUDA ext modules import and run; both 0.1.2 packages build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)